### PR TITLE
Updated to use Bearer token as 23andMe only supports that method now. 

### DIFF
--- a/lib/passport-23andme/strategy.js
+++ b/lib/passport-23andme/strategy.js
@@ -74,7 +74,8 @@ util.inherits(Strategy, OAuth2Strategy);
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
 
-  this._oauth2.getProtectedResource('https://api.23andme.com/1/names/', accessToken, function (err, body, res) {
+  this._oauth2.useAuthorizationHeaderforGET(true);
+  this._oauth2.get('https://api.23andme.com/1/names/', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profiles', err)); }
 
     try {


### PR DESCRIPTION
Also replaced deprecated oauth2 method.
